### PR TITLE
SWI-Prolog WebAssembly link change

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This repo contains a list of languages that currently compile to or have their V
 ### <a name="prolog"></a>Prolog <sup>[top⇈](#contents)</sup>
 
 > Prolog is a general-purpose logic programming language associated with artificial intelligence and computational linguistics. Prolog has its roots in first-order logic, a formal logic, and unlike many other programming languages, Prolog is intended primarily as a declarative programming language: the program logic is expressed in terms of relations, represented as facts and rules. A computation is initiated by running a query over these relations.
-* [SWI-Prolog port to WebAssembly](https://github.com/rla/swi-prolog-wasm) - a port of SWI-Prolog to WebAssembly. SWI-Prolog is a free implementation of the programming language Prolog commonly used for teaching and semantic web applications.
+* [SWI-Prolog port to WebAssembly](https://github.com/SWI-Prolog/swipl-wasm) - a port of SWI-Prolog to WebAssembly. SWI-Prolog is a free implementation of the programming language Prolog commonly used for teaching and semantic web applications.
 
 --------------------
 


### PR DESCRIPTION
The informative repository was copied directly under the SWI-Prolog organization. Follows up PR #17.