### PR TITLE
update doc, mark 2 as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repo contains a list of languages that currently compile to or have their V
 :hatched_chick: [C#](#csharp)</br>
 :hatched_chick: [C++](#cpp)</br>
 :hatched_chick: [Clean](#clean)</br>
+:egg: [Co](#co)</br>
 :hatched_chick: [COBOL](#cobol)</br>
 :hatching_chick: [D](#d)</br>
 :hatching_chick: [Elixir](#elixir)</br>
@@ -57,7 +58,6 @@ This repo contains a list of languages that currently compile to or have their V
 :hatching_chick: [Walt](#walt)</br>
 :hatching_chick: [Wam](#wam)</br>
 :egg: ~[Wracket](#wracket)~ `Unmaintained`</br>
-:egg: [Xlang](#xlang)</br>
 :hatched_chick: [Zig](#zig)</br>
 
 --------------------
@@ -66,6 +66,7 @@ This repo contains a list of languages that currently compile to or have their V
 > .NET Framework is a software framework developed by Microsoft that runs primarily on Microsoft Windows. It includes a large class library named Framework Class Library (FCL) and provides language interoperability (each language can use code written in other languages) across several programming languages.
 * [Mono](https://github.com/mono/mono/tree/master/sdks/wasm) - an open source implementation of Microsoft's .NET Framework based on the ECMA standards for C# and the Common Language Runtime. For a real-work example, see this repository which contains the [Windows 10 calculator](https://github.com/nventive/calculator). The application is built using standard C++ 11 and C++/CX, with a calculation engine that dates back from 1995. Made by possible with mono via [Uno Platform](https://platform.uno/a-piece-of-windows-10-is-now-running-on-webassembly-natively-on-ios-and-android/).
 * [Blazor](https://github.com/aspnet/blazor) - an experimental web UI framework using C#/Razor and HTML, running client-side via WebAssembly.
+
 --------------------
 
 ### <a name="assemblyscript"></a>AssemblyScript <sup>[top⇈](#contents)</sup>
@@ -119,6 +120,12 @@ This repo contains a list of languages that currently compile to or have their V
 > Some of its most notable language features are uniqueness typing, dynamic typing, and generic functions.
 * [ABC interpreter](https://gitlab.science.ru.nl/clean-and-itasks/abc-interpreter) - interpreter for Clean's intermediate language ABC, with a WebAssembly version.
 * [iTasks](https://gitlab.science.ru.nl/clean-and-itasks/iTasks-SDK) - integration of the above ABC interpreter with browser applications.
+
+--------------------
+
+### <a name="co"></a>Co <sup>[top⇈](#contents)</sup>
+> A programming language similar to Go and TypeScript.
+* [Co](https://github.com/rsms/co) - main repository
 
 --------------------
 
@@ -390,12 +397,6 @@ This repo contains a list of languages that currently compile to or have their V
 ### <a name="wracket"></a>Wracket <sup>[top⇈](#contents)</sup>
 > A lisp-like language that compiles to WebAssembly, written in racket
 * [Wracket](https://github.com/sschauss/wracket) - main repository.
-
---------------------
-
-### <a name="xlang"></a>Co <sup>[top⇈](#contents)</sup>
-> A programming language similar to Go and TypeScript.
-* [Co](https://github.com/rsms/co) - main repository
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This repo contains a list of languages that currently compile to or have their V
 ### <a name="elixir"></a>Elixir <sup>[top⇈](#contents)</sup>
 > Elixir is a dynamic, functional language designed for building scalable and maintainable applications.
 > Elixir builds on top of Erlang and shares the same abstractions for building distributed, fault-tolerant applications.
-* [ElixirWasm](https://github.com/jamen/elixir-wasm) - an elixir compiler for wasm.
+* ~[ElixirWasm](https://github.com/jamen/elixir-wasm) - an elixir compiler for wasm. [Unmaintained]~
 * [Lumen](https://github.com/lumen/lumen) - An alternative BEAM implementation (with AOT compiler) designed for WebAssembly.
 
 --------------------
@@ -186,7 +186,7 @@ This repo contains a list of languages that currently compile to or have their V
 > Haskell is a standardized, general-purpose purely functional programming language, with non-strict semantics and strong static typing. It is named after logician Haskell Curry.[1] The latest standard of Haskell is Haskell 2010. As of May 2016, a group is working on the next version, Haskell 2020.
 * [Asterius](https://github.com/tweag/asterius) - a Haskell to WebAssembly compiler
 * [DHC](https://github.com/dfinity/dhc) - a Haskell compiler that accepts only a tiny subset of the language and produces WebAssembly binaries.
-* [HaskellWasm](https://github.com/haskell-wasm/wasm) - a Haskell compiler infrastructure for generating WebAssembly.
+* ~[HaskellWasm](https://github.com/haskell-wasm/wasm) - a Haskell compiler infrastructure for generating WebAssembly. [Unmaintained]~
 * [haskell-wasm](https://github.com/SPY/haskell-wasm) - Haskell WebAssembly Toolkit. It includes Language helpers and a fully spec-compatible WASM interpreter.
 
 --------------------
@@ -267,7 +267,7 @@ This repo contains a list of languages that currently compile to or have their V
 ### <a name="ocaml"></a>Ocaml <sup>[top⇈](#contents)</sup>
 > OCaml, originally named Objective Caml, is the main implementation of the programming language Caml, created by Xavier Leroy, Jérôme Vouillon, Damien Doligez, Didier Rémy, Ascánder Suárez and others in 1996. A member of the ML language family, OCaml extends the core Caml language with object-oriented programming constructs.
 * [Ocaml](https://github.com/SanderSpies/ocaml/tree/wasm/wasmcomp) - a fork of main repo contianing work on OCaml to wasm compilation.
-* ~[OcamlRun](https://github.com/sebmarkbage/ocamlrun-wasm) - a build script for compiling OCaml bytecode interpreter to wasm using emscripten [Unmaintained]~.
+* ~[OcamlRun](https://github.com/sebmarkbage/ocamlrun-wasm) - a build script for compiling OCaml bytecode interpreter to wasm using emscripten [Unmaintained]~
 
 --------------------
 
@@ -393,9 +393,9 @@ This repo contains a list of languages that currently compile to or have their V
 
 --------------------
 
-### <a name="xlang"></a>Xlang <sup>[top⇈](#contents)</sup>
+### <a name="xlang"></a>Co <sup>[top⇈](#contents)</sup>
 > A programming language similar to Go and TypeScript.
-* [Xlang](https://github.com/rsms/xlang) - main repository
+* [Co](https://github.com/rsms/co) - main repository
 
 --------------------
 


### PR DESCRIPTION
[ElixirWasm](https://github.com/jamen/elixir-wasm) and [HaskellWasm](https://github.com/sdiehl/wasm) are now archived and unmaintained
Xlang got renamed to [Co](https://github.com/rsms/xlang)