### PR TITLE
Update Schism URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ This repo contains a list of languages that currently compile to or have their V
 
 ### <a name="scheme"></a>Scheme <sup>[top⇈](#contents)</sup>
 > Scheme is a programming language that supports multiple paradigms, including functional programming and imperative programming, and is one of the two main dialects of Lisp. Unlike Common Lisp, the other main dialect, Scheme follows a minimalist design philosophy specifying a small standard core with powerful tools for language extension..
-* [Schism](https://github.com/google/schism) - Schism is an experimental self-hosting compiler from a subset of R6RS Scheme to WebAssembly. Development so far has focused on features necessary for self-hosting. The compiler itself is written in, and compiles, a very small subset of Scheme.
+* [Schism](https://github.com/schism-lang/schism) - Schism is an experimental self-hosting compiler from a subset of R6RS Scheme to WebAssembly. Development so far has focused on features necessary for self-hosting. The compiler itself is written in, and compiles, a very small subset of Scheme.
 
 --------------------
 


### PR DESCRIPTION
The Schism URL was pointing to an archived version of the repository. This PR
updates the link to point to the new version.