### PR TITLE
Add SpiderMonkey to JavaScript section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ This repo contains a list of languages that currently compile to or have their V
 ### <a name="javascript"></a>JavaScript <sup>[top⇈](#contents)</sup>
 > JavaScript is a high-level, interpreted programming language that conforms to the ECMAScript specification. It is a language that is also characterized as dynamic, weakly typed, prototype-based and multi-paradigm.
 * [Duktape](https://github.com/svaarala/duktape) - an embeddable Javascript engine, with a focus on portability and compact footprint that's capable of being run in the browser via WebAssembly.
+* [SpiderMonkey](https://github.com/bytecodealliance/spidermonkey-wasm-rs) - experimental Rust bindings and generic builtins for SpiderMonkey for building WASI-compatible modules from JavaScript.
 
 --------------------
 


### PR DESCRIPTION
This PR adds a link to [SpiderMonkey](https://github.com/bytecodealliance/spidermonkey-wasm-rs), which can be used to generate WASI-compatible Wasm modules from JavaScript using the SpiderMonkey JS engine.