### PR TITLE
Change status of crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repo contains a list of languages that currently compile to or have their V
 :hatched_chick: [Clean](#clean)</br>
 :egg: [Co](#co)</br>
 :hatched_chick: [COBOL](#cobol)</br>
-:egg: [Crystal](#crystal)</br>
+:hatching_chick: [Crystal](#crystal)</br>
 :hatching_chick: [D](#d)</br>
 :hatching_chick: [Eclair](#eclair)</br>
 :hatching_chick: [Eel](#eel)</br>


### PR DESCRIPTION
The linked [PR](https://github.com/crystal-lang/crystal/pull/10870) for crystal was merged and released in crystal version [1.4.0](https://crystal-lang.org/2022/04/06/1.4.0-released.html)

I found out as I recently saw this [article](https://glue.im/noah/introduction-to-webassembly-in-crystal) demonstrating it.