### PR TITLE
Add Dart to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repo contains a list of languages that currently compile to or have their V
 :egg: [Co](#co)</br>
 :hatched_chick: [COBOL](#cobol)</br>
 :egg: [Crystal](#crystal)</br>
+:egg: [Dart](#dart)</br>
 :hatching_chick: [D](#d)</br>
 :hatching_chick: [Eclair](#eclair)</br>
 :hatching_chick: [Eel](#eel)</br>
@@ -182,6 +183,13 @@ This repo contains a list of languages that currently compile to or have their V
 ### <a name="d"></a>D <sup>[top⇈](#contents)</sup>
 > D is a general-purpose programming language with static typing, systems-level access, and C-like syntax.
 * [LDC](https://github.com/ldc-developers/ldc) - LLVM-based D compiler, which can generate WASM since version 1.11.0.
+
+--------------------
+
+### <a name="dart"></a>Dart <sup>[top⇈](#contents)</sup>
+> Dart is a client-optimized language for developing fast apps on any platform. Its goal is to offer the most productive programming language for multi-platform development, paired with a flexible execution runtime platform for app frameworks.
+* [sdk](https://github.com/dart-lang/sdk) - The Dart SDK, including the VM, dart2js, core libraries, and more.
+* [language](https://github.com/dart-lang/language) - Design of the Dart language
 
 --------------------
 


### PR DESCRIPTION
Featuring [dart2wasm](https://dart.dev/web/js-interop)

Fixes #97 