### PR TITLE
fix #130 producation & unmaintained Categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,30 @@ This repo contains a list of languages that currently compile to or have their V
 
 ## Contents
 
+- :chicken: - In Production.
+  - [C](#c)
+  - [C++](#cpp)
+  - [Rust](#rust)
+  - [Go](#go)
+  
 - :hatched_chick: - Stable for production usage.
   - [.Net](#dotnet)
   - [AssemblyScript](#assemblyscript)
   - [Brainfuck](#brainfuck)
-  - [C](#c)
   - [C#](#csharp)
-  - [C++](#cpp)
   - [Clean](#clean)
   - [Cyber](#cyber)
   - [COBOL](#cobol)
   - [F#](#fsharp)
   - [Forth](#forth)
-  - [Go](#go)
   - [Grain](#grain)
   - [Lobster](#lobster)
   - [Lox](#lox)
   - [Lua](#lua)
   - [Nelua](#nelua)
   - [Never](#never)
-  - [Rust](#rust)
   - [Rego](#rego)</br>
   - [TypeScript](#typescript)
-  - ~[Wah](#wah)~ `Unmaintained`
   - [WebAssembly](#webassembly)
   - [Zig](#zig)</br>
   
@@ -40,7 +41,6 @@ This repo contains a list of languages that currently compile to or have their V
   - [Eclair](#eclair)
   - [Eel](#eel)
   - [Elixir](#elixir)
-  - ~[Idris](#idris)~ `Unmaintained`
   - [Java](#java)
   - [JavaScript](#javascript)
   - [KCL](#kcl)
@@ -57,15 +57,11 @@ This repo contains a list of languages that currently compile to or have their V
   - [Ruby](#ruby)</br>
   - [Scheme](#scheme)
   - [Scopes](#scopes)
-  - ~[Speedy.js](#speedyjs)~ `Unmaintained`
   - [Swift](#swift)
-  - ~[Turboscript](#turboscript)~ `Unmaintained`
   - [V](#v)
-  - ~[Walt](#walt)~ `Unmaintained`
-  - ~[Wam](#wam)~ `Unmaintained`
+
   
 - :egg: - Work in progress.
-  - ~[Astro](#astro)~ `Unmaintained`
   - [Ballerina](#ballerina)
   - [Co](#co)
   - [Dart](#dart)
@@ -79,8 +75,18 @@ This repo contains a list of languages that currently compile to or have their V
   - [Plorth](#plorth)
   - [Wa](#wa)
   - [Wase](#wase)
-  - ~[Wracket](#wracket)~ `Unmaintained`
   - [xcc](#xcc)</br>
+
+- :skull_and_crossbones: - Unmaintained or Deprecated
+  - ~[Wah](#wah)~ `Unmaintained`
+  - ~[Idris](#idris)~ `Unmaintained`
+  - ~[Speedy.js](#speedyjs)~ `Unmaintained`
+  - ~[Turboscript](#turboscript)~ `Unmaintained`
+  - ~[Walt](#walt)~ `Unmaintained`
+  - ~[Wam](#wam)~ `Unmaintained`
+  - ~[Astro](#astro)~ `Unmaintained`
+  - ~[Wracket](#wracket)~ `Unmaintained`
+  
 
 --------------------
 


### PR DESCRIPTION
fixes #130 
Also i think rest of the categories require state update as some of the languages have gotten better stability while some have been unmaintained and deprecated.
languages like never & cobaul havent been updated in years yet they are tagged "stable" . IMHO languages that havent been updated in 9months should move towards the unmaintained category.