### PR TITLE
Added GPython, Wonkey, NerdLang, RingLang, 4 BASICs, 5 Luas, 3 JSs, 1 Scheme, 1 Go, 3 Golang scripting-s

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ This repo contains a list of languages that currently compile to or have their V
 > Go is a statically typed compiled language in the tradition of C, with memory safety, garbage collection, structural typing, and CSP-style concurrent programming features added.
 * [Go](https://github.com/golang/go) - main repository.
 * [TinyGo](https://github.com/aykevl/tinygo) - a subset of Go targeted to embedded devices and WebAssembly.
+* [Yaegi](https://github.com/traefik/yaegi) - Yaegi is Another Elegant Go Interpreter, implemented in pure Go. It powers executable Go scripts and plugins, in embedded interpreters or interactive shells, on top of the Go runtime.
 
 --------------------
 
@@ -340,6 +341,9 @@ This repo contains a list of languages that currently compile to or have their V
 * [SpiderMonkey](https://github.com/bytecodealliance/spidermonkey-wasm-rs) - experimental Rust bindings and generic builtins for SpiderMonkey for building WASI-compatible modules from JavaScript.
 * [quickjs-emscripten](https://github.com/justjake/quickjs-emscripten) - Safely execute untrusted Javascript in your JS/TS, and execute synchronous code that uses async functions.
 * [wasmedge-quickjs](https://github.com/second-state/wasmedge-quickjs) - A high-performance, secure, extensible, and OCI-complaint JavaScript runtime for WasmEdge.  Features TCP/UDP support via WasmEdge Sockets.
+* [Boa](https://github.com/boa-dev/boa) - an embeddable and experimental Javascript engine written in Rust. You can try it out [here](https://boajs.dev/boa/playground/).
+* [goja](https://github.com/dop251/goja) - an implementation of ECMAScript 5.1 in pure Go with emphasis on standard compliance and performance.
+* [otto](https://github.com/robertkrimen/otto) - a JavaScript parser and interpreter written natively in Go.
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repo contains a list of languages that currently compile to or have their V
   
 - :hatching_chick: - Unstable but usable.
   - [Ada](#ada)
+  - [BASIC](#basic)
   - [C4wa](#c4wa)
   - [Crystal](#crystal)
   - [D](#d)
@@ -62,6 +63,7 @@ This repo contains a list of languages that currently compile to or have their V
   - [Tcl](#tcl)
   - [V](#v)
   - [Virgil](#virgil)
+  - [Wonkey](#wonkey)
   
 - :egg: - Work in progress.
   - [Ballerina](#ballerina)
@@ -72,6 +74,7 @@ This repo contains a list of languages that currently compile to or have their V
   - [Haskell](#haskell)
   - [Julia](#julia)
   - [Kou](#kou)
+  - [Nerd](#nerd)
   - [Nim](#nim)
   - [Ocaml](#ocaml)
   - [Plorth](#plorth)
@@ -125,6 +128,16 @@ This repo contains a list of languages that currently compile to or have their V
 > Ballerina is an open-source programming language for the cloud that makes it easier to use, combine, and create network services.
 > The WebAssembly compiler is implemented for the native Ballerina compiler [nBallerina](https://github.com/ballerina-platform/nballerina).
 * [Main repository](https://github.com/ballerina-platform/nballerina/tree/wasm) - Ballerina-to-wasm compiler 
+
+--------------------
+
+### <a name="basic"></a>BASIC <sup>[top⇈](#contents)</sup>
+> BASIC (acronym for "Beginners' All-purpose Symbolic Instruction Code") is an early general-purpose and high-level programming language. It's still one of the simplest and easy to learn languages. 
+
+* [basic_rs](https://github.com/yiransheng/basic_rs) - a BASIC Interpreter/Compiler for the Original Dartmouth Version written in Rust. Also provides `basic2wasm` tool which compiles BASIC to WebAssembly using binaryen. 
+* [basicwasm](https://github.com/navionguy/basicwasm) - a GWBasic interpreter compiled to WASM with a Web UI.
+* [EndBASIC](https://github.com/endbasic/endbasic) - BASIC environment with a REPL, a web interface, a graphical console, and RPi support written in Rust. You can try it out [here](https://repl.endbasic.dev/).
+* [gobasic](https://github.com/skx/gobasic) - a BASIC interpreter written in Golang.
 
 --------------------
 
@@ -277,6 +290,14 @@ This repo contains a list of languages that currently compile to or have their V
 * [TinyGo](https://github.com/aykevl/tinygo) - a subset of Go targeted to embedded devices and WebAssembly.
 
 --------------------
+
+#### <a name="go-scripting"></a>Golang scripting languages <sup>[top⇈](#contents)</sup>
+> These languages are implemented in Golang, have Golang-like syntax in general, and may be used as scripting inside Go programs. Each of them deserves its own section in this list, and will get it eventually when its ecosystem will grow up.
+* [Anko](https://github.com/mattn/anko) - scriptable interpreter written in Golang.
+* [Risor](https://github.com/risor-io/risor) - fast and flexible scripting for Go developers and DevOps. Its modules integrate the Go standard library. You can try it out [here](https://risor.io/#editor).
+* [Tengo](https://github.com/d5/tengo) - a small, dynamic, fast, secure script language for Go. You can try it out [here](https://tengolang.com/).
+
+--------------------
 ### <a name="grain"></a>Grain <sup>[top⇈](#contents)</sup>
 > Grain is a strongly-typed functional programming language built for the modern web.
 * [Grain](https://github.com/grain-lang/grain) - main repository.
@@ -382,6 +403,11 @@ This repo contains a list of languages that currently compile to or have their V
 * [Luwa](https://github.com/serprex/luwa) - a Lua-to-wasm JIT compiler.
 * [Wasmoon](https://github.com/ceifa/wasmoon) - a high level Lua VM with JS bindings.
 * [Wasm2Lua](https://github.com/SwadicalRag/wasm2lua) - can compile WebAssembly modules to pure Lua (or with FFI LuaJIT for extra speed).
+* [DCLua](https://github.com/milochristiansen/lua) - a Lua 5.3 VM and compiler written in Go. It's intended to allow easy embedding into Go programs, with minimal fuss and bother.
+* [go-lua](https://github.com/Shopify/go-lua) - a port of the Lua 5.2 VM to pure Go. It is compatible with binary files dumped by `luac`. The motivation is to enable simple scripting of Go applications.
+* [GopherLua](https://github.com/yuin/gopher-lua) - a Lua5.1(+ goto statement in Lua5.2) VM and compiler written in Go. It provides Go APIs that allow you to easily embed a scripting language to your Go host programs.  
+* [ofunc/lua](https://github.com/erdian718/lua) - a fork of DCLua, featuring IO capabilities, HTTP client, IoC, and more.  
+* [Pluto](https://github.com/PlutoLang/Pluto) - a superset of Lua 5.4 - with unique features, optimizations, and improvements, which aims to specialize for general-purpose programming. You can try it out [here](https://pluto-lang.org/web/).
 
 --------------------
 
@@ -396,6 +422,13 @@ This repo contains a list of languages that currently compile to or have their V
 > Minimal, simple, efficient, statically typed, compiled, metaprogrammable, safe, and extensible systems programming language with a Lua flavor.
 * [Nelua](https://github.com/edubart/nelua-lang/) - project repository
 * [Nelua on the Web](https://github.com/edubart/nelua-lang/discussions/11) - Nelua-wasm discussion
+
+--------------------
+
+### <a name="nerd"></a>Nerd <sup>[top⇈](#contents)</sup>
+> NerdLang is a substract of JS with some additions, focus on efficiency.
+> Nerd is a JavaScript native compiler aiming to make JavaScript universal, Nerd is able to compile native apps for Windows, Mac, Linux, iOS, Android, Raspberry, STM32, Arduino, Web (including WASM), and more.
+* [Nerd](https://github.com/NerdLang/nerd) - main repository.
 
 --------------------
 
@@ -464,6 +497,7 @@ This repo contains a list of languages that currently compile to or have their V
 * [RPython](https://github.com/soIu/rpython) - A RPython (PyPy's Restricted Python) to WebAssembly compiler
 * [TPython](https://github.com/soIu/tpython) - Pythonic++ (a "dialect" of C++) to WebAssembly compiler
 * [micropython-wasm](https://github.com/rafi16jan/micropython-wasm) - MicroPython build which features wide JS interop, e.g. waiting for JS promises.
+* [gpython](https://github.com/go-python/gpython) - GPython is a Python 3.4 interpreter written in Go "batteries not included". Can be used as embedded language in Go programs.
 
 --------------------
 
@@ -616,6 +650,12 @@ This repo contains a list of languages that currently compile to or have their V
 > Yes, WebAssembly. `Wasm3` is the fastest WebAssembly interpreter, that enables WebAssembly self-hosting.
 * [Wasm3](https://github.com/wasm3/wasm3) - main repository.
 * [Wasm3 on WAPM](https://wapm.io/package/vshymanskyy/wasm3) - WAPM package.
+
+--------------------
+
+### <a name="wonkey"></a>Wonkey <sup>[top⇈](#contents)</sup>
+> Wonkey is an easy to learn, object-oriented, modern and cross-platform programming language for creating cross-platform video games, highly inspired by the "BlitzBasic" range of languages.
+* [Wonkey](https://github.com/wonkey-coders/wonkey) - main repository. Check the demo games [here](https://wonkey-coders.github.io/examples/).
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This repo contains a list of languages that currently compile to or have their V
   - [Python](#python)
   - [Prolog](#prolog)
   - [R](#r)
+  - [Ring](#ring)
   - [Ruby](#ruby)</br>
   - [Scheme](#scheme)
   - [Scopes](#scopes)
@@ -292,7 +293,7 @@ This repo contains a list of languages that currently compile to or have their V
 --------------------
 
 #### <a name="go-scripting"></a>Golang scripting languages <sup>[top⇈](#contents)</sup>
-> These languages are implemented in Golang, have Golang-like syntax in general, and may be used as scripting inside Go programs. Each of them deserves its own section in this list, and will get it eventually when its ecosystem will grow up.
+> These languages are implemented in Golang, have Golang-like syntax in general, and may be used as scripting inside Go programs. Each of them deserves its own section in this list, and will get it eventually as ecosystem grows up.
 * [Anko](https://github.com/mattn/anko) - scriptable interpreter written in Golang.
 * [Risor](https://github.com/risor-io/risor) - fast and flexible scripting for Go developers and DevOps. Its modules integrate the Go standard library. You can try it out [here](https://risor.io/#editor).
 * [Tengo](https://github.com/d5/tengo) - a small, dynamic, fast, secure script language for Go. You can try it out [here](https://tengolang.com/).
@@ -530,6 +531,16 @@ This repo contains a list of languages that currently compile to or have their V
 
 --------------------
 
+### <a name="ring"></a>Ring <sup>[top⇈](#contents)</sup>
+
+> Ring is a Simple, Small, and Flexible practical general-purpose multi-paradigm language. The supported programming paradigms are Imperative, Procedural, Object-Oriented, Functional, Metaprogramming, Declarative programming using nested structures, and Natural programming.
+> The language is portable (MS-DOS, Windows, Linux, macOS, Android, WebAssembly, etc.) and can be used to create Console, GUI, Web, Games, and Mobile applications.
+
+* [Ring](https://github.com/ring-lang/ring) - main repository. You can try it out [here](https://tio.run/#ring).
+* [WASM apps in Ring](https://ring-lang.github.io/doc1.19/qtwebassembly.html#online-applications) - list of demo web applications implemented in Ring.
+
+--------------------
+
 ### <a name="ruby"></a>Ruby <sup>[top⇈](#contents)</sup>
 > Ruby is an open source interpreted high-level programming language for general-purpose programming. Created by Matz. Ruby has a design philosophy that emphasizes code readability, notably using as few sigils (special chars`:.{}%[]&=>;`) as possible.
 * [Wruby](https://github.com/pannous/wruby) Web ruby - a port of minimal ruby (mruby).
@@ -557,6 +568,7 @@ This repo contains a list of languages that currently compile to or have their V
 > Scheme is a programming language that supports multiple paradigms, including functional programming and imperative programming, and is one of the two main dialects of Lisp. Unlike Common Lisp, the other main dialect, Scheme follows a minimalist design philosophy specifying a small standard core with powerful tools for language extension..
 * [Schism](https://github.com/schism-lang/schism) - Schism is an experimental self-hosting compiler from a subset of R6RS Scheme to WebAssembly. Development so far has focused on features necessary for self-hosting. The compiler itself is written in, and compiles, a very small subset of Scheme.
 * [scheme.wasm](https://github.com/pollrobots/scheme) - An R7RS Scheme implemented in WebAssembly. You can try it out [here](https://pollrobots.com/scheme/).
+* [Guile Hoot](https://gitlab.com/spritely/guile-hoot) - a Scheme to WebAssembly compiler backend for GNU Guile and a general purpose WASM toolchain.
 
 --------------------
 


### PR DESCRIPTION
Added GPython, Wonkey, NerdLang, RingLang,
BASIC section (basic_rs, basicwasm, EndBASIC, gobasic), 
Luas (DCLua, go-lua, GopherLua, ofunc/lua, Pluto), 
JavaScripts (Boa, goja, otto),
Schemes (Guile Hoot),
Golangs (Yaegi),
Golang scripting languages subsection (Anko, Risor, Tengo).