### PR TITLE
Update status for Wa

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ This repo contains a list of languages that currently compile to or have their V
 
 > 凹语言™（凹读音“Wa”）是 针对 WASM 平台设计的的通用编程语言，支持 Linux、macOS 和 Windows 等主流操作系统和 Chrome 等浏览器环境，同时也支持作为独立Shell脚本和被嵌入脚本模式执行。
 
-* [Wa/凹语言(Engilish)](https://wa-lang.github.io/) - Design for WebAssembly.
+* [Wa/凹语言(English)](https://wa-lang.github.io/) - Design for WebAssembly.
 * [Wa/凹语言(简体中文)](https://wa-lang.org/) - 凹语言 - 为 WebAssembly 而生.
 * [Wa/凹语言(仓库)](https://github.com/wa-lang/wa) - main repository.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ This repo contains a list of languages that currently compile to or have their V
   - [Tcl](#tcl)
   - [V](#v)
   - [Virgil](#virgil)
-  
+  - [Wa](#wa)
+
 - :egg: - Work in progress.
   - [Ballerina](#ballerina)
   - [Co](#co)
@@ -75,7 +76,6 @@ This repo contains a list of languages that currently compile to or have their V
   - [Nim](#nim)
   - [Ocaml](#ocaml)
   - [Plorth](#plorth)
-  - [Wa](#wa)
   - [Wase](#wase)
   - [xcc](#xcc)</br>
 
@@ -584,7 +584,9 @@ This repo contains a list of languages that currently compile to or have their V
 
 > 凹语言™（凹读音“Wa”）是 针对 WASM 平台设计的的通用编程语言，支持 Linux、macOS 和 Windows 等主流操作系统和 Chrome 等浏览器环境，同时也支持作为独立Shell脚本和被嵌入脚本模式执行。
 
-* [Wa/凹语言](https://github.com/wa-lang/wa) - main repository.
+* [Wa/凹语言(Engilish)](https://wa-lang.github.io/) - Design for WebAssembly.
+* [Wa/凹语言(简体中文)](https://wa-lang.org/) - 凹语言 - 为 WebAssembly 而生.
+* [Wa/凹语言(仓库)](https://github.com/wa-lang/wa) - main repository.
 
 --------------------
 


### PR DESCRIPTION
Wa-lang is unstable but usable.

- NES emulator: https://wa-lang.org/nes/
  - https://github.com/wa-lang/nes
- WebGPU Demo (Only support PC/Chrome): https://wa-lang.org/webgpu/
  - https://github.com/wa-lang/webgpu

![](https://wa-lang.org/st0036-01.png)

![](https://wa-lang.org/st0036-02.png)

Wa talk on KCD(Chinese): https://wa-lang.org/smalltalk/st0036.html
