### PR TITLE
Added Boa, Goja, Otto to JS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ This repo contains a list of languages that currently compile to or have their V
 * [SpiderMonkey](https://github.com/bytecodealliance/spidermonkey-wasm-rs) - experimental Rust bindings and generic builtins for SpiderMonkey for building WASI-compatible modules from JavaScript.
 * [quickjs-emscripten](https://github.com/justjake/quickjs-emscripten) - Safely execute untrusted Javascript in your JS/TS, and execute synchronous code that uses async functions.
 * [wasmedge-quickjs](https://github.com/second-state/wasmedge-quickjs) - A high-performance, secure, extensible, and OCI-complaint JavaScript runtime for WasmEdge.  Features TCP/UDP support via WasmEdge Sockets.
+* [Boa](https://github.com/boa-dev/boa) - an embeddable and experimental Javascript engine written in Rust. You can try it out [here](https://boajs.dev/boa/playground/).
+* [goja](https://github.com/dop251/goja) - an implementation of ECMAScript 5.1 in pure Go with emphasis on standard compliance and performance.
+* [otto](https://github.com/robertkrimen/otto) - a JavaScript parser and interpreter written natively in Go.
 
 --------------------
 


### PR DESCRIPTION
Added Boa, Goja, Otto to JavaScript section.

#### Proofs

* Boa - [presents](https://github.com/boa-dev/boa#live-demo-wasm) a WASM-based [playground](https://boajs.dev/boa/playground/)
* Goja - An oversimplified [example](https://github.com/wasm-outbound-http-examples/js-in-go/blob/7ed91aaa8dad2cb322a4dddab8df76a9194dfe8f/browser-and-deno-goja/main.go#L7) is available. This small progam embeds a goja VM as library and a JS code as string. After compiling to WASM, this program results to a single WASM file and works well in browsers and Deno+Bun. Browser demo is [here](https://wasm-outbound-http-examples.github.io/js-in-go/goja/)
* Otto - An oversimplified [example](https://github.com/wasm-outbound-http-examples/js-in-go/blob/7ed91aaa8dad2cb322a4dddab8df76a9194dfe8f/browser-and-deno-otto/main.go#L7) is available too. This small progam embeds an Otto interpreter as library and a JS code as string. After compiling to WASM, this program results to a single WASM file and works well in browsers and Deno+Bun. Its browser demo is [here](https://wasm-outbound-http-examples.github.io/js-in-go/otto/).
 
This is a JavaScript portion of #140 .