### PR TITLE
Added GPython, Pocketpy, and Emscripten-Forge's PyJS to Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,8 +475,8 @@ This repo contains a list of languages that currently compile to or have their V
 * [micropython-wasm](https://github.com/rafi16jan/micropython-wasm) - MicroPython build which features wide JS interop, e.g. waiting for JS promises.
 * [WebAssembly Language Runtimes](https://github.com/vmware-labs/webassembly-language-runtimes) - up-to-date CPython prebuilt for WASI
 * [gpython](https://github.com/go-python/gpython) - GPython is a Python 3.4 interpreter written in Go "batteries not included". Can be used as embedded language in Go programs.
-* [pyjs](https://github.com/emscripten-forge/pyjs) - Python <=> JavaScript bindings using high level embind and pybind11. You can try it out [here](https://emscripten-forge.github.io/sample-python-repl/). 
-* [pocketpy](https://github.com/pocketpy/pocketpy) - pkpy is a lightweight (~15K LOC of C++ in single header file) Python interpreter for game scripting. It's easy to embed, has no external dependencies. You can try its REPL out [here](https://pocketpy.dev/static/web/). 
+* [pyjs](https://github.com/emscripten-forge/pyjs) - Python <=> JavaScript bindings using high level embind and pybind11. You can try it out [here](https://emscripten-forge.github.io/pyjs/lite/) and [here](https://emscripten-forge.github.io/sample-python-repl/). 
+* [pocketpy](https://github.com/pocketpy/pocketpy) - pkpy is a lightweight (~15K LOC of C11 in single header file) Python 3.x interpreter for game scripting. It's easy to embed, has no external dependencies. You can try its REPL out [here](https://pocketpy.dev/static/web/). 
 
 --------------------
 


### PR DESCRIPTION
Added GPython and Emscripten-Forge's PyJS to Python section.

#### Proofs

* GPython - A single-file [example](https://github.com/wasm-outbound-http-examples/gpython/blob/f389d141e039d507c00610dd9230ddd23cd89faa/browser-and-deno/main.go#L7) is available. This small progam embeds a GPython VM as library and a Python code as strings. After compiling to WASM, this program results to a single WASM file and works well in browsers and Deno+Bun. Browser demo is [here](https://wasm-outbound-http-examples.github.io/gpython/)
* PyJS - [defined](https://github.com/emscripten-forge/pyjs/blob/1.3.2/docs/_src/faq.md#what-is-pyjs) as WASM port of Python interpreter. Also has [demo REPL](https://emscripten-forge.github.io/sample-python-repl/).
*  Pocketpy - implemented in single file of C++ with no dependencies. Can be compiled to WASM with Emscripten. Also has a WASM-powered [demo REPL](https://pocketpy.dev/static/web/).


This is a Python portion of #140 .