### PR TITLE
Added Yaegi, Anko, Risor, Tengo to Golang section

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,15 @@ This repo contains a list of languages that currently compile to or have their V
 > Go is a statically typed compiled language in the tradition of C, with memory safety, garbage collection, structural typing, and CSP-style concurrent programming features added.
 * [Go](https://github.com/golang/go) - main repository.
 * [TinyGo](https://github.com/aykevl/tinygo) - a subset of Go targeted to embedded devices and WebAssembly.
+* [Yaegi](https://github.com/traefik/yaegi) - Yaegi is Another Elegant Go Interpreter, implemented in pure Go. It powers executable Go scripts and plugins, in embedded interpreters or interactive shells, on top of the Go runtime.
+
+--------------------
+
+#### <a name="go-scripting"></a>Golang scripting languages <sup>[top⇈](#contents)</sup>
+> These languages are implemented in Golang, have Golang-like syntax in general, and may be used as scripting inside Go programs. Each of them deserves its own section in this list, and will get it eventually as ecosystem grows up.
+* [Anko](https://github.com/mattn/anko) - scriptable interpreter written in Golang.
+* [Risor](https://github.com/risor-io/risor) - fast and flexible scripting for Go developers and DevOps. Its modules integrate the Go standard library. You can try it out [here](https://risor.io/#editor).
+* [Tengo](https://github.com/d5/tengo) - a small, dynamic, fast, secure script language for Go. You can try it out [here](https://tengolang.com/).
 
 --------------------
 ### <a name="grain"></a>Grain <sup>[top⇈](#contents)</sup>


### PR DESCRIPTION
Added Yaegi to Golang section.
Added Golang Scripting subsection containing Anko, Risor, Tengo.

#### Proofs

All these languages are tested to WASM compatibility in the same manner: created a simple Go program, which imports the particutar language interpreter as library. When that program compiled to WASM to single `main.wasm` file, which has been tested in browser and Deno+Bun.

* Yaegi - [example](https://github.com/wasm-outbound-http-examples/yaegi/blob/deecf7e8840e5c5b7e15921aec4c2c29d03838e6/browser-and-deno/main.go#L4). Browser demo is [here](https://wasm-outbound-http-examples.github.io/yaegi/)
* Anko - [example](https://github.com/wasm-outbound-http-examples/anko/blob/aa01ffaad3153254ae2abbf432b16b33b315574e/browser/main.go#L9), Browser demo is [here](https://wasm-outbound-http-examples.github.io/anko/)
* Risor - [example](https://github.com/wasm-outbound-http-examples/risor/blob/0e6a935c8124bf11fd100bea600dd0eb4ed7cd37/browser/main.go#L7), Browser demo is [here](https://wasm-outbound-http-examples.github.io/risor/)
* Tengo - [example](https://github.com/wasm-outbound-http-examples/tengo/blob/964f7a4d17449e3fccd7a908314513d932b10514/browser-and-deno-tengohttp/main.go#L6), Browser demo is [here](https://wasm-outbound-http-examples.github.io/tengo/tengohttp/).

This is a Golang-related portion of #140 .