### PR TITLE
Added Guile Hoot, NerdLang, RingLang, and Wonkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This repo contains a list of languages that currently compile to or have their V
   - [Python](#python)
   - [Prolog](#prolog)
   - [R](#r)
+  - [Ring](#ring)
   - [Ruby](#ruby)</br>
   - [Scheme](#scheme)
   - [Scopes](#scopes)
@@ -64,6 +65,7 @@ This repo contains a list of languages that currently compile to or have their V
   - [V](#v)
   - [Virgil](#virgil)
   - [Wa](#wa)
+  - [Wonkey](#wonkey)
 
 - :egg: - Work in progress.
   - [Ballerina](#ballerina)
@@ -74,6 +76,7 @@ This repo contains a list of languages that currently compile to or have their V
   - [Haskell](#haskell)
   - [Julia](#julia)
   - [Kou](#kou)
+  - [Nerd](#nerd)
   - [Nim](#nim)
   - [Ocaml](#ocaml)
   - [Plorth](#plorth)
@@ -407,6 +410,13 @@ This repo contains a list of languages that currently compile to or have their V
 
 --------------------
 
+### <a name="nerd"></a>Nerd <sup>[top⇈](#contents)</sup>
+> NerdLang is a substract of JS with some additions, focus on efficiency.
+> Nerd is a JavaScript native compiler aiming to make JavaScript universal, Nerd is able to compile native apps for Windows, Mac, Linux, iOS, Android, Raspberry, STM32, Arduino, Web (including WASM), and more.
+* [Nerd](https://github.com/NerdLang/nerd) - main repository.
+
+--------------------
+
 ### <a name="never"></a>Never <sup>[top⇈](#contents)</sup>
 > Never is a simple functional programming language. Technically it may be classified as syntactically scoped, strongly typed, call by value, functional programming language.
 * [Never](https://github.com/never-lang/never) - project repository
@@ -506,6 +516,15 @@ This repo contains a list of languages that currently compile to or have their V
 
 --------------------
 
+### <a name="ring"></a>Ring <sup>[top⇈](#contents)</sup>
+
+> Ring is a Simple, Small, and Flexible practical general-purpose multi-paradigm language. The supported programming paradigms are Imperative, Procedural, Object-Oriented, Functional, Metaprogramming, Declarative programming using nested structures, and Natural programming.
+> The language is portable (MS-DOS, Windows, Linux, macOS, Android, WebAssembly, etc.) and can be used to create Console, GUI, Web, Games, and Mobile applications.
+* [Ring](https://github.com/ring-lang/ring) - main repository. You can try it out [here](https://tio.run/#ring).
+* [WASM apps in Ring](https://ring-lang.github.io/doc1.19/qtwebassembly.html#online-applications) - list of demo web applications implemented in Ring.
+
+--------------------
+
 ### <a name="ruby"></a>Ruby <sup>[top⇈](#contents)</sup>
 > Ruby is an open source interpreted high-level programming language for general-purpose programming. Created by Matz. Ruby has a design philosophy that emphasizes code readability, notably using as few sigils (special chars`:.{}%[]&=>;`) as possible.
 * [Wruby](https://github.com/pannous/wruby) Web ruby - a port of minimal ruby (mruby).
@@ -535,6 +554,7 @@ This repo contains a list of languages that currently compile to or have their V
 > Scheme is a programming language that supports multiple paradigms, including functional programming and imperative programming, and is one of the two main dialects of Lisp. Unlike Common Lisp, the other main dialect, Scheme follows a minimalist design philosophy specifying a small standard core with powerful tools for language extension..
 * [Schism](https://github.com/schism-lang/schism) - Schism is an experimental self-hosting compiler from a subset of R6RS Scheme to WebAssembly. Development so far has focused on features necessary for self-hosting. The compiler itself is written in, and compiles, a very small subset of Scheme.
 * [scheme.wasm](https://github.com/pollrobots/scheme) - An R7RS Scheme implemented in WebAssembly. You can try it out [here](https://pollrobots.com/scheme/).
+* [Guile Hoot](https://gitlab.com/spritely/guile-hoot) - a Scheme to WebAssembly compiler backend for GNU Guile and a general purpose WASM toolchain.
 
 --------------------
 
@@ -630,6 +650,12 @@ This repo contains a list of languages that currently compile to or have their V
 > Yes, WebAssembly. `Wasm3` is the fastest WebAssembly interpreter, that enables WebAssembly self-hosting.
 * [Wasm3](https://github.com/wasm3/wasm3) - main repository.
 * [Wasm3 on WAPM](https://wapm.io/package/vshymanskyy/wasm3) - WAPM package.
+
+--------------------
+
+### <a name="wonkey"></a>Wonkey <sup>[top⇈](#contents)</sup>
+> Wonkey is an easy to learn, object-oriented, modern and cross-platform programming language for creating cross-platform video games, highly inspired by the "BlitzBasic" range of languages.
+* [Wonkey](https://github.com/wonkey-coders/wonkey) - main repository. Check the demo games [here](https://wonkey-coders.github.io/examples/).
 
 --------------------
 


### PR DESCRIPTION
Added NerdLang, RingLang, and Wonkey sections.
Added Guile Hoot to Scheme section.

#### Reasoning

* Guile Hoot - [declared](https://gitlab.com/spritely/guile-hoot#guile-hoot) as `Guile->WebAssembly
project`. It's usable enough to [build interactive web pages](https://spritely.institute/news/building-interactive-web-pages-with-guile-hoot.html), and more.
* Nerd - [declares](https://github.com/NerdLang/nerd/blob/400b367708c2fee58060f85fb8546a522c8add9c/README.md?plain=1#L133) WASM as supported platform. Has an JS-interop [example](
https://github.com/NerdLang/nerd/blob/400b367708c2fee58060f85fb8546a522c8add9c/example/wasm_binding.ng#L8). I've tested that example and it worked as expected. (But "compiler" itself needs to be patched to work on case-sensitive filesystem).
* Ring - [declares](https://github.com/ring-lang/ring#webassembly-front-end-web-development) WASM support and has list of WASM [demos](https://ring-lang.github.io/doc1.19/qtwebassembly.html#online-applications).
* Wonkey - [has](https://github.com/wonkey-coders/wonkey/blob/b47047b2e37acefd21a64c60811ebd614caf2ef3/src/wake/wake.wx#L116) WASM as default compilation target. Uses Emscripten under the scenes. Has several demo games [here](https://wonkey-coders.github.io/examples/).

This is a "Major additions" portion of #140 .