### PR TITLE
Added DCLua, erdian718/lua, GopherLua, and Pluto to Lua section

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,10 @@ This repo contains a list of languages that currently compile to or have their V
 * [Luwa](https://github.com/serprex/luwa) - a Lua-to-wasm JIT compiler.
 * [Wasmoon](https://github.com/ceifa/wasmoon) - a high level Lua VM with JS bindings.
 * [Wasm2Lua](https://github.com/SwadicalRag/wasm2lua) - can compile WebAssembly modules to pure Lua (or with FFI LuaJIT for extra speed).
+* [DCLua](https://github.com/milochristiansen/lua) - a Lua 5.3 VM and compiler written in Go. It's intended to allow easy embedding into Go programs, with minimal fuss and bother.
+* [erdian718/lua](https://github.com/erdian718/lua) (aka ofunc/lua) - a fork of DCLua, featuring IO capabilities, HTTP client, IoC, and more.
+* [GopherLua](https://github.com/yuin/gopher-lua) - a Lua5.1(+ goto statement in Lua5.2) VM and compiler written in Go. It provides Go APIs that allow you to easily embed a scripting language to your Go host programs.
+* [Pluto](https://github.com/PlutoLang/Pluto) - a superset of Lua 5.4 - with unique features, optimizations, and improvements, which aims to specialize for general-purpose programming. You can try it out [here](https://pluto-lang.org/web/).
 
 --------------------
 


### PR DESCRIPTION
Added DCLua, erdian718/lua aka ofunc/lua, GopherLua, and Pluto to Lua section.

#### Proofs

* Pluto - has [wasm builds](https://github.com/PlutoLang/wasm-builds/tree/3576815593a5adf2190b7e66d17f441d63b8d64d/out/pluto/0.8.1) and WASM-enabled [playground](https://pluto-lang.org/web/).
* GopherLua - [example](https://github.com/wasm-outbound-http-examples/lua-in-go/blob/edde8a27b0c34d50b89640ba40f64152d94ae8cb/browser-gluahttp/main.go#L7). This small progam embeds a GopherLua VM as library and a Lua code as string. After compiling to WASM, this program results to a single WASM file and works well in browsers. Browser demo is  [here](https://wasm-outbound-http-examples.github.io/lua-in-go/gluahttp/).
* DCLua - I've tested  in browser an (converted from unit test to executable program) [example](https://github.com/milochristiansen/lua/blob/f20e777b03ba247c8d9141e420c43665165e9da8/example_test.go#L80) compiled to WASM, and it works.
* erdian718/lua (aka ofunc/lua) - [example](https://github.com/wasm-outbound-http-examples/lua-in-go/blob/edde8a27b0c34d50b89640ba40f64152d94ae8cb/browser-lmodhttpclient/main.go#L8). This progam embeds a ofunc/lua VM as library and a Lua code as string. After compiling to WASM, this program results to a single WASM file and works well in browsers. Browser demo is [here](https://wasm-outbound-http-examples.github.io/lua-in-go/lmodhttpclient/).

This is a Lua portion of #140 .

[Shopify/go-lua](https://github.com/Shopify/go-lua) has issues compiling to WASM, and therefore it's not added at this time.