### PR TITLE
Added basic_rs, basicwasm, EndBASIC, gobasic to new BASIC section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This repo contains a list of languages that currently compile to or have their V
 
 - :egg: - Work in progress.
   - [Ballerina](#ballerina)
+  - [BASIC](#basic)
   - [Co](#co)
   - [Dart](#dart)
   - [Faust](#faust)
@@ -126,6 +127,15 @@ This repo contains a list of languages that currently compile to or have their V
 > Ballerina is an open-source programming language for the cloud that makes it easier to use, combine, and create network services.
 > The WebAssembly compiler is implemented for the native Ballerina compiler [nBallerina](https://github.com/ballerina-platform/nballerina).
 * [Main repository](https://github.com/ballerina-platform/nballerina/tree/wasm) - Ballerina-to-wasm compiler 
+
+--------------------
+
+### <a name="basic"></a>BASIC <sup>[top⇈](#contents)</sup>
+> BASIC (acronym for "Beginners' All-purpose Symbolic Instruction Code") is an early general-purpose and high-level programming language. It's still one of the simplest and easy to learn languages.
+* [basic_rs](https://github.com/yiransheng/basic_rs) - a BASIC Interpreter/Compiler for the Original Dartmouth Version written in Rust. Also provides `basic2wasm` tool which compiles BASIC to WebAssembly using binaryen.
+* [basicwasm](https://github.com/navionguy/basicwasm) - a GWBasic interpreter compiled to WASM with a Web UI.
+* [EndBASIC](https://github.com/endbasic/endbasic) - BASIC environment with a REPL, a web interface, a graphical console, and RPi support written in Rust. You can try it out [here](https://repl.endbasic.dev/).
+* [gobasic](https://github.com/skx/gobasic) - a BASIC interpreter written in Golang.
 
 --------------------
 


### PR DESCRIPTION
Added basic_rs, basicwasm, EndBASIC, and gobasic to new BASIC section.

#### Proofs

* basic_rs - [declares](https://github.com/yiransheng/basic_rs/blob/ddd64e2eacfc2b36354e32e2b6abdb97989bd3a2/basic2wasm/README.md) WASM support and has Game of Life [demo](http://subdued-afternoon.surge.sh) compiled from BASIC [source](https://github.com/yiransheng/basic_rs/blob/ddd64e2eacfc2b36354e32e2b6abdb97989bd3a2/basic2wasm/example/source.bas).
* basicwasm - Built and tested its web REPL. At least `PRINT`, `LOCATE`, `CLS`, `COLOR` commands work well.
* EndBASIC - [advertises](https://github.com/endbasic/endbasic/blob/endbasic-0.10.0/repl/examples/tour.bas#L61-L62) WASM support and provides a [web REPL](https://github.com/endbasic/endbasic/blob/endbasic-0.10.0/web/README.md?plain=1#L28) as demo [here](https://repl.endbasic.dev/).
* gobasic - I've compiled [embed example](https://github.com/skx/gobasic/blob/release-2.2/embed/main.go) to WASM and printing works well: it prints the expected text into browser console.

This is a BASIC portion of #140 .