### PR TITLE
Added Roc

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This repo contains a list of languages that currently compile to or have their V
   - [Nim](#nim)
   - [Ocaml](#ocaml)
   - [Plorth](#plorth)
+  - [Roc](#roc)
   - [Wase](#wase)
   - [xcc](#xcc)</br>
 
@@ -503,6 +504,16 @@ This repo contains a list of languages that currently compile to or have their V
 * [dotnet-opa-wasm](https://github.com/christophwille/dotnet-opa-wasm) - Call OPA policies in Wasm from C# .NET Core.
 * [python-opa-wasm](https://github.com/a2d24/python-opa-wasm) - OPA Wasm SDK for Python.
 * [java-opa-wasm](https://github.com/sangkeon/java-opa-wasm) - OPA Wasm SDK for Java.
+
+--------------------
+
+### <a name="roc"></a>Roc <sup>[top⇈](#contents)</sup>
+
+> A fast, friendly, functional language. Compiles to machine code or WASM. Roc is a direct descendant of the Elm programming language.
+
+* [roc](https://github.com/roc-lang/roc) - main repository. You can try it out [here](https://www.roc-lang.org/#try-roc).
+* [basic-cli](https://github.com/roc-lang/basic-cli) - a Roc [platform](https://github.com/roc-lang/roc/wiki/Roc-concepts-explained#platform) to work with files, commands, HTTP, TCP, command line arguments, etc.
+* [basic-webserver](https://github.com/roc-lang/basic-webserver) - a basic Web Server for Roc.
 
 --------------------
 


### PR DESCRIPTION
Added Roc-lang.

#### Proofs

Roc [declares](https://github.com/roc-lang/roc/blob/943d7a3cdfdc73706228d42be66406b0aa6c7d1f/www/content/index.md?plain=1#L17) WASM as compilation target. 
Roc has a WASM-powered [REPL](https://www.roc-lang.org/#try-roc) which has Roc's compiler itself compiled to WASM and  [compiles user input into WASM to execute it in browser](https://github.com/roc-lang/roc/blob/943d7a3cdfdc73706228d42be66406b0aa6c7d1f/crates/repl_wasm/README.md?plain=1#L44).