### PR TITLE
Added Jint, Porffor, and sebastianwessel-quickjs to JavaScript section

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,9 @@ This repo contains a list of languages that currently compile to or have their V
 * [goja](https://github.com/dop251/goja) - an implementation of ECMAScript 5.1 in pure Go with emphasis on standard compliance and performance.
 * [otto](https://github.com/robertkrimen/otto) - a JavaScript parser and interpreter written natively in Go.
 * [hermes](https://github.com/facebook/hermes) - Hermes is a JavaScript engine optimized for fast start-up of React Native apps. It features ahead-of-time static optimization and compact bytecode. [Emscripten](https://github.com/facebook/hermes/blob/main/doc/Emscripten.md) and [WASI](https://github.com/guest271314/hermes/blob/shermes-wasm/doc/WASI.md) support.
+* [Jint](https://github.com/sebastienros/jint) - an embeddable Javascript interpreter for .NET which can run on any modern .NET platform as it supports .NET Standard 2.0 and .NET 4.6.2 targets (and later).
+* [Porffor](https://github.com/CanadaHonk/porffor) - a from-scratch experimental AOT optimizing JS/TS -> Wasm/C engine/compiler/runtime. You can try it out [here](https://porffor.dev/).
+* [sebastianwessel-quickjs](https://github.com/sebastianwessel/quickjs) - a typescript package to execute JavaScript and TypeScript code in a webassembly quickjs sandbox. You can try it out [here](https://sebastianwessel.github.io/quickjs/playground.html).
 
 --------------------
 


### PR DESCRIPTION
Added Jint, Porffor, and sebastianwessel-quickjs to JavaScript section.

#### Proofs

* Jint 
  - implemented in pure C#. Can be embedded to .Net program, which compiles to WASM seamlessly (tested it).
* Porffor - it's experimental and alpha, but unique and very promising.
  - [declares](https://github.com/CanadaHonk/porffor/blob/5e26327fba507fb17f658aff02e14bd6912da3de/README.md#compiling-to-wasm) support to compile JS to WASM.
  - has a [playground](https://porffor.dev/) at the bottom of page, there it compiles JS snippets to WAT and C.
* sebastianwessel-quickjs
  - [declares](https://github.com/sebastianwessel/quickjs/tree/v2.0.1?tab=readme-ov-file#quickjs---execute-javascript-and-typescript-in-a-webassembly-quickjs-sandbox) itself as a WASM sandbox for executing JS/TS.
  - has a WASM-enabled [playground](https://sebastianwessel.github.io/quickjs/playground.html).