### PR TITLE
Add Lateralus programming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This repo contains a list of languages that currently compile to or have their V
   - [Haskell](#haskell)
   - [Julia](#julia)
   - [Kou](#kou)
+  - [Lateralus](#lateralus)
   - [MoonBit](#moonbit)
   - [Nerd](#nerd)
   - [Nim](#nim)
@@ -450,6 +451,13 @@ This repo contains a list of languages that currently compile to or have their V
 * [GopherLua](https://github.com/yuin/gopher-lua) - a Lua5.1(+ goto statement in Lua5.2) VM and compiler written in Go. It provides Go APIs that allow you to easily embed a scripting language to your Go host programs.
 * [Pluto](https://github.com/PlutoLang/Pluto) - a superset of Lua 5.4 with a focus on general-purpose programming. You can try it out [here](https://pluto-lang.org/web/).
 * [PlutoScript](https://github.com/PlutoLang/PlutoScript) - Pluto's extension aimed for web scripting. Provides JS interop and ability to use Pluto anywhere JavaScript works.  
+
+--------------------
+
+### <a name="lateralus"></a>Lateralus <sup>[top⇈](#contents)</sup>
+> Lateralus is a pipeline-native programming language with pattern matching, algebraic data types, type inference, and borrow checking. Compiles to C, LLVM, and WebAssembly.
+
+* [Lateralus](https://github.com/bad-antics/lateralus-lang) - main repository.
 
 --------------------
 


### PR DESCRIPTION
Adding [Lateralus](https://github.com/bad-antics/lateralus-lang) to the work-in-progress section.

## About Lateralus

A pipeline-native programming language that compiles to WebAssembly (as well as C and LLVM).

### Features
- Pattern matching and algebraic data types
- Type inference with borrow checking
- Pipeline-native syntax for data flow
- Multiple backends: C, LLVM, WASM
- Built-in LSP and VS Code extension

### WASM Support
Lateralus compiles to WASM via its LLVM backend, enabling browser and edge deployment. Still in active development.