### PR TITLE
Add remove-audio.com - free browser-based audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,3 +780,6 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 [![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Steve Akinyemi](https://github.com/appcypher) has waived all copyright and related or neighboring rights to this work.
+
+
+* [Remove audio from video](https://remove-audio.com) - Free, browser-based audio remover. Local processing via WebAssembly. No signup, no watermarks. Batch up to 20 clips.


### PR DESCRIPTION
This adds https://remove-audio.com to the list.

It is a free, browser-based tool that strips audio from video files using FFmpeg.wasm and WebAssembly. All processing is local - no files are uploaded to any server. No signup, no watermarks, batch support for up to 20 clips.

Fits this list because: it is a free web tool for video processing.