### PR TITLE
Update Ballerina section for new native interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,8 @@ This repo contains a list of languages that currently compile to or have their V
 --------------------
 
 ### <a name="ballerina"></a>Ballerina <sup>[top⇈](#contents)</sup>
-> Ballerina is an open-source programming language for the cloud that makes it easier to use, combine, and create network services.
-> The WebAssembly compiler is implemented for the native Ballerina compiler [nBallerina](https://github.com/ballerina-platform/nballerina).
-* [Main repository](https://github.com/ballerina-platform/nballerina/tree/wasm) - Ballerina-to-wasm compiler 
+> Ballerina is an open-source, cloud-native programming language focused on integration and network services.
+* [ballerina-lang-go](https://github.com/ballerina-platform/ballerina-lang-go) - Native Ballerina interpreter written in Go with WebAssembly support. You can try Ballerina [here](https://play.ballerina.io/).
 
 --------------------
 


### PR DESCRIPTION
- Updated the Ballerina section in README.md to replace discontinued nballerina references with ballerina-lang-go.
- Refined the description to clearly state that ballerina-lang-go is a native Ballerina interpreter written in Go with WebAssembly support.
- Added the official Ballerina playground link for quick try-out access.